### PR TITLE
Change default vm size to larger size in web.tfvars file

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -66,7 +66,7 @@ variable "azure_linux_virtual_machine" {
   type = map(
     object({
       location = optional(string, "westus")
-      size     = optional(string, "Standard_B1ls")
+      size     = optional(string, "Standard_B2als_v2")
       count    = optional(number, 0)
 
       storage_image_reference_vars = optional(object({


### PR DESCRIPTION
Changed default vm size to a larger size, previous size was too small for use