### PR TITLE
Fix standard virtual machine size not being available in westus region

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -66,11 +66,7 @@ variable "azure_linux_virtual_machine" {
   type = map(
     object({
       location = optional(string, "westus")
-<<<<<<< HEAD
       size     = optional(string, "Standard_B2s")
-=======
-      size     = optional(string, "Standard_B1ls")
->>>>>>> parent of 699aed3 (Change default vm size to larger size in web.tfvars file)
       count    = optional(number, 0)
 
       storage_image_reference_vars = optional(object({

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -66,7 +66,11 @@ variable "azure_linux_virtual_machine" {
   type = map(
     object({
       location = optional(string, "westus")
-      size     = optional(string, "Standard_B2als_v2")
+<<<<<<< HEAD
+      size     = optional(string, "Standard_B2s")
+=======
+      size     = optional(string, "Standard_B1ls")
+>>>>>>> parent of 699aed3 (Change default vm size to larger size in web.tfvars file)
       count    = optional(number, 0)
 
       storage_image_reference_vars = optional(object({


### PR DESCRIPTION
Change default virtual machine size to Standard_B2s for terraform apply to be valid