### PR TITLE
Change terraform config from remote backend to cloud

### DIFF
--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_version = ">= 1.6"
 
-  backend "remote" {
+  cloud {
     organization = "cacloudstudio"
 
     workspaces {


### PR DESCRIPTION
As per HCP Terraform documentation, use cloud block config over remote backend