### PR TITLE
Cl/tf pipeline secretsfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,14 +131,15 @@ echo "##vso[task.setvariable variable=ARM_SUBSCRIPTION_ID]$ARM_SUBSCRIPTION_ID"
 
 echo "##vso[task.setvariable variable=ARM_CLIENT_ID]$servicePrincipalId"
 echo "##vso[task.setvariable variable=ARM_TENANT_ID]$tenantId"
-echo "##vso[task.setvariable variable=ARM_CLIENT_SECRET]$servicePrincipalKey"
 ```
 
-6. In future tasks that require use of Terraform scripts, set the env: block like below. This will allow Terraform's Azurerm to automatically authenticate to your Azure subscription.
+6. It is not recommended to pass use these commands to set secrets. Thus, we will manually set the pipeline variable for client secret. Head to the pipeline, then go to **Edit** --> **Variables** and hit the plus sign next to the search bar. Enter in the variable name, and the client secret copied earlier as the value. Be sure to check the box that says "Keep this value secret".
+
+7. In future tasks that require use of Terraform scripts, set the env: block like below. This will allow Terraform's Azurerm to automatically authenticate to your Azure subscription.
 ```bash
 env:
   ARM_CLIENT_ID: $(ARM_CLIENT_ID)
-  ARM_CLIENT_SECRET: $(ARM_CLIENT_SECRET)
+  ARM_CLIENT_SECRET: $(SECRET_VARIABLE_NAME)
   ARM_SUBSCRIPTION_ID: $(ARM_SUBSCRIPTION_ID)
   ARM_TENANT_ID: $(ARM_TENANT_ID)
 ```

--- a/ado/steps/azure-pipelines-ansible.yml
+++ b/ado/steps/azure-pipelines-ansible.yml
@@ -34,7 +34,7 @@ stages:
               RunAsPreJob: true
           - script: |
               echo "Setting keyvault password as variable"
-              echo "##vso[task.setvariable variable=AZURE_VM_PASSWORD;isOutput=true]$web-0-secret
+              echo "##vso[task.setvariable variable=AZURE_VM_PASSWORD;isOutput=true]$web-0-secret"
             displayName: "Get VM Password"
             name: GetVMPw
 

--- a/ado/steps/azure-pipelines-ansible.yml
+++ b/ado/steps/azure-pipelines-ansible.yml
@@ -56,7 +56,7 @@ stages:
 
       - job: AnsibleRun
         displayName: "Run Ansible Playbook"
-        dependsOn: Azure Connection
+        dependsOn: AzureConnection
         steps:
           - script: |
               cd ..

--- a/ado/steps/azure-pipelines-tf.yml
+++ b/ado/steps/azure-pipelines-tf.yml
@@ -90,16 +90,6 @@ stages:
             inputs:
               targetType: "inline"
               script: |
-                echo "Test for Az CLI environment variables"
-                echo $ARM_CLIENT_ID
-                echo $ARM_SUBSCRIPTION_ID
-                echo $ARM_TENANT_ID
-                echo "Test for Client secret"
-                echo $ARM_CLIENT_SECRET
-                cd $(Build.SourcesDirectory)
-                ls -al
-                pwd
-                terraform --version
                 echo "Initializing Terraform with remote backend"
                 cd $(Build.SourcesDirectory)/$(TF_DIR)
                 pwd
@@ -120,17 +110,8 @@ stages:
             inputs:
               targetType: "inline"
               script: |
-                cd $(Build.SourcesDirectory)/$(TF_DIR)
-                echo "All files under directory here."
-                ls -al
-
-                echo "Test terraform versioning"
-                terraform -v
+                echo "Terraform Apply"
                 terraform apply main.tfplan
-
-                echo "Planning:"
-                terraform plan -destroy -var-file=tfvars/$(TF_VAR_DIR)/$(TF_VAR_DIR).tfvars -out=de.tfplan
-                terraform apply de.tfplan
             env:
               TF_TOKEN_app_terraform_io: $(TERRAFORM_TOKEN)
               ARM_CLIENT_ID: $(ARM_CLIENT_ID)

--- a/ado/steps/azure-pipelines-tf.yml
+++ b/ado/steps/azure-pipelines-tf.yml
@@ -82,7 +82,6 @@ stages:
                 echo "##vso[task.setvariable variable=ARM_CLIENT_ID]$servicePrincipalId"
                 echo "##vso[task.setvariable variable=ARM_SUBSCRIPTION_ID]$ARM_SUBSCRIPTION_ID"
                 echo "##vso[task.setvariable variable=ARM_TENANT_ID]$tenantId"
-                echo "##vso[task.setvariable variable=ARM_CLIENT_SECRET]$servicePrincipalKey"
               addSpnToEnvironment: true
 
           - task: Bash@3
@@ -99,7 +98,7 @@ stages:
             env:
               TF_TOKEN_app_terraform_io: $(TERRAFORM_TOKEN)
               ARM_CLIENT_ID: $(ARM_CLIENT_ID)
-              ARM_CLIENT_SECRET: $(ARM_CLIENT_SECRET)
+              ARM_CLIENT_SECRET: $(SERVICE_PRINCIPAL_KEY)
               ARM_SUBSCRIPTION_ID: $(ARM_SUBSCRIPTION_ID)
               ARM_TENANT_ID: $(ARM_TENANT_ID)
             displayName: "Terraform Plan"
@@ -116,6 +115,6 @@ stages:
             env:
               TF_TOKEN_app_terraform_io: $(TERRAFORM_TOKEN)
               ARM_CLIENT_ID: $(ARM_CLIENT_ID)
-              ARM_CLIENT_SECRET: $(ARM_CLIENT_SECRET)
+              ARM_CLIENT_SECRET: $(SERVICE_PRINCIPAL_KEY)
               ARM_SUBSCRIPTION_ID: $(ARM_SUBSCRIPTION_ID)
               ARM_TENANT_ID: $(ARM_TENANT_ID)

--- a/ado/steps/azure-pipelines-tf.yml
+++ b/ado/steps/azure-pipelines-tf.yml
@@ -110,6 +110,7 @@ stages:
             inputs:
               targetType: "inline"
               script: |
+                cd $(Build.SourcesDirectory)/$(TF_DIR)
                 echo "Terraform Apply"
                 terraform apply main.tfplan
             env:


### PR DESCRIPTION
It is not recommended (per Microsoft documentation) to set secrets as variables directly in the yaml script using task.setvariable. Thus, we introduce this workaround by manually setting pipeline variable. Changes reflected in README as well.